### PR TITLE
Stand Ranking and Build Errors Fix

### DIFF
--- a/src/InputParametersParser.cs
+++ b/src/InputParametersParser.cs
@@ -985,17 +985,16 @@ namespace Landis.Library.HarvestManagement
                                                                         beginTimeVar.Value.String));
                         if (endTime > scenarioEnd)
                         {
-                                throw new InputValueException(endTimeVar.Value.String,
-                                                              string.Format("Year {0} is after the scenario' end year ({1})",
-                                                                            endTimeVar.Value.String,
-                                                                            scenarioEnd));
-
                             string line1 = string.Format("   NOTE: End Year {0} is after the scenario' end year {1}", endTimeVar.Value.String, scenarioEnd);
                             string line2 = string.Format("         on line {0} of the harvest input file...", LineNumber);
                             List<string> noteList = new List<string>();
                             noteList.Add(line1);
                             noteList.Add(line2);
                             parserNotes.Add(noteList);
+                            throw new InputValueException(endTimeVar.Value.String,
+                                                              string.Format("Year {0} is after the scenario' end year ({1})",
+                                                                            endTimeVar.Value.String,
+                                                                            scenarioEnd));  
                         }
 
                         CheckNoDataAfter("the " + endTimeVar.Name + " column",

--- a/src/SiteVars.cs
+++ b/src/SiteVars.cs
@@ -129,7 +129,7 @@ namespace Landis.Library.HarvestManagement
         /// </remarks>
         public static void GetExternalVars()
         {
-            TimeOfLastFire = Model.Core.GetSiteVar<int>("Fire.TimeOfLastEvent");
+            TimeOfLastFire = Model.Core.GetSiteVar<int>("Fire.TimeOfLastFire");
             TimeOfLastWind = Model.Core.GetSiteVar<int>("Wind.TimeOfLastEvent");
             CFSFuelType = Model.Core.GetSiteVar<int>("Fuels.CFSFuelType");
             NextBDA = Model.Core.GetSiteVar<int>("BDA.TimeOfNext");

--- a/src/stand-ranking/FireRiskRank.cs
+++ b/src/stand-ranking/FireRiskRank.cs
@@ -27,7 +27,7 @@ namespace Landis.Library.HarvestManagement
         protected override double ComputeRank(Stand stand, int i)
         {
 
-            SiteVars.ReInitialize();
+            SiteVars.GetExternalVars();
             //if (SiteVars.CFSFuelType == null)
             //    throw new System.ApplicationException("Error: CFS Fuel Type NOT Initialized.  Fuel extension MUST be active.");
 


### PR DESCRIPTION
Slightly changed Library-Harvest-Mgmt to use the correct name for the time of last fire event variable and also had Base-Fire register this variable for external use. Also fixed warnings that appear when building Library-Harvest-Mgmt.